### PR TITLE
Removed commented code

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -135,7 +135,6 @@ module.exports = grammar(
             metadata_assignment: $ => seq(
                 optional($.orderer),
                 $.identifier,
-                // choice(alias($._special_names, $.identifier), $.identifier),
                 "=",
                 choice($.list_proxy, $.list, $._metadata_value),
             ),
@@ -336,7 +335,6 @@ module.exports = grammar(
                 $.attribute_type,
                 choice(
                     $.identifier,
-                    // alias($._special_names, $.identifier),
                     // It's rare but it's valid for a dict to contain string identifiers
                     // e.g.
                     //
@@ -362,7 +360,6 @@ module.exports = grammar(
             _inner_dictionary_assignment: $ => seq(
                 $._dictionary_type,
                 choice(
-                    // alias($._special_names, $.identifier),
                     $.identifier,
                     $.string,  // ``$.string`` seems to be uncommon
                 ),

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
             "scope": "source.usd"
         }
     ],
-    "version": "0.3.0"
+    "version": "0.4.0"
 }

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,14 +1,27 @@
 (None) @constant.builtin
-(asset_path) @string.special.asset
+(asset_path) @text.uri
+(attribute_property) @property
 (bool) @boolean
 (comment) @comment @spell
 (custom) @function.builtin
 (float) @float
 (integer) @number
-(namespace_identifier) @namespace
 (orderer) @function.call
-(prim_path) @string.special.prim
+(prim_path) @string.special
+(relationship_type) @type
 (uniform) @function.builtin
+(variant_set_definition) @keyword
+
+;; Prefer namespace highlighting, if any.
+;;
+;; e.g. `rel fizz` - `fizz` uses `@identifier`
+;; e.g. `rel foo:bar:fizz` - `foo` and `bar` use `@namespace` and `fizz` uses `@identifier`
+;;
+(namespace_identifier) @namespace
+(namespace_identifier
+  (identifier) @namespace
+)
+(identifier) @variable
 
 [
   "class"
@@ -22,25 +35,6 @@
 [
   "="
 ] @operator
-
-;; Simple variables
-(attribute_assignment
- (identifier) @variable
-)
-(attribute_declaration
- (identifier) @variable
-)
-(relationship_declaration
- (identifier) @variable
-)
-(relationship_assignment
- (identifier) @variable
-)
-(qualified_identifier
-  (identifier) @variable)
-
-;; Attribute components
-(attribute_property) @property
 
 (attribute_type) @type
 (
@@ -104,24 +98,6 @@
  )
 )
 
-;; Relationships
-(relationship_type) @type
-(relationship_assignment
-  (identifier) @variable
-)
-(relationship_declaration
-  (identifier) @variable
-)
-
-(variant_set_definition) @keyword
-
-;; String rules
-(attribute_assignment
- (string) @string)
-(dictionary
- (string) @string)
-(list
- (string) @string)
 ; In USD def "foo" ("This is a docstring") {} < the ""s within the ()s is not
 ; a string but a docstring
 ;
@@ -129,23 +105,5 @@
  (comment)*
  .
  (string) @comment.documentation)
-(metadata_assignment
- (string) @string)
-(prim_definition
- (string) @string)
-(variant_set_definition
- (string) @string)
-(variant
- (string) @string)
 
-;; Layer metadata
-(metadata_assignment
- (identifier) @variable)
-(dictionary
- (identifier) @variable)
-
-;; Docstrings in USD
-(metadata
- (comment)*
- (string) @comment.documentation
-)
+(string) @string

--- a/test/corpus/namespace.txt
+++ b/test/corpus/namespace.txt
@@ -1,0 +1,16 @@
+==============================================================================
+namespace materials
+==============================================================================
+
+rel material:another:binding
+
+------------------------------------------------------------------------------
+
+(module
+  (relationship_declaration
+    (relationship_type)
+    (qualified_identifier
+      (namespace_identifier
+        (namespace_identifier)
+        (identifier))
+      (identifier))))

--- a/test/highlight/assetInfo.usda
+++ b/test/highlight/assetInfo.usda
@@ -7,12 +7,12 @@ def Xform "cube" (
         asset identifier = @./Cube.txt@
         # <- type
         #     ^ variable
-        #                  ^ string.special.asset
+        #                  ^ text.uri
         asset[] payloadAssetDependencies = [@fizz.usd@, @buzz.usd@]
         # <- type
         #       ^ variable
-        #                                   ^ string.special.asset
-        #                                               ^ string.special.asset
+        #                                   ^ text.uri
+        #                                               ^ text.uri
         string version = "v1"
         int foo = 8
     }

--- a/test/highlight/assetPath.usda
+++ b/test/highlight/assetPath.usda
@@ -1,7 +1,7 @@
 def "root" (
     add references = @foo.usda@</Model> (offset = 1; scale = 2.0)
-                      # <- string.special.asset
-                      #        ^ string.special.prim
+                      # <- text.uri
+                      #        ^ string.special
                       #                           ^ number
                       #                            ^ punctuation.delimiter
                       #                                      ^ float

--- a/test/highlight/attribute.usda
+++ b/test/highlight/attribute.usda
@@ -8,7 +8,7 @@ def Scope "Prim"
     #           ^ namespace
     #               ^ variable
     #                     ^ property
-    #                               ^ string.special.prim
+    #                               ^ string.special
 }
 
 

--- a/test/highlight/clips.usda
+++ b/test/highlight/clips.usda
@@ -9,11 +9,11 @@ def "World"
                 asset manifestAssetPath = @./clip_manifest.usda@
                 # <- type
                 #     ^ variable
-                #                         ^ string.special.asset
+                #                         ^ text.uri
                 asset[] assetPaths = [@./clip.usda@]
                 # <- type
                 #       ^ variable
-                #                     ^ string.special.asset
+                #                     ^ text.uri
                 double templateEndTime   = 3
                 # <- type
                 #      ^ variable

--- a/test/highlight/inherits.usda
+++ b/test/highlight/inherits.usda
@@ -1,7 +1,7 @@
 def "foo" (
     inherits = </thing>
     # <- variable
-    #          ^ string.special.prim
+    #          ^ string.special
 )
 {
 }

--- a/test/highlight/namespace.usda
+++ b/test/highlight/namespace.usda
@@ -1,0 +1,6 @@
+rel material:another:binding = </asdffsd>
+#   ^ namespace
+#           ^ punctuation.delimiter
+#            ^ namespace
+#                   ^ punctuation.delimiter
+#                    ^ variable

--- a/test/highlight/payload.usda
+++ b/test/highlight/payload.usda
@@ -2,8 +2,8 @@ def "foo" (
     add payload = @foo.usda@</foo>
     # <- function.call
     #   ^ variable
-    #             ^ string.special.asset
-    #                       ^ string.special.prim
+    #             ^ text.uri
+    #                       ^ string.special
 )
 {
 }

--- a/test/highlight/references.usda
+++ b/test/highlight/references.usda
@@ -2,9 +2,9 @@ over "Parent" (
     prepend references = [</InternalRef>, @./ref.usda@</RefParent>]
     # <- function.call
     #       ^ variable
-    #                     ^ string.special.prim
-    #                                     ^ string.special.asset
-    #                                                 ^ string.special.prim
+    #                     ^ string.special
+    #                                     ^ text.uri
+    #                                                 ^ string.special
 )
 {
 }

--- a/test/highlight/relationship.usda
+++ b/test/highlight/relationship.usda
@@ -22,15 +22,15 @@ rel material:binding:collection:Erasers = None
 rel foo = </foo/child>
 # <- type
 #   ^ variable
-#         ^ string.special.prim
+#         ^ string.special
 
 rel material:binding:collection:Erasers = [
 # <- type
 #   ^ namespace
     </foo/child>,
-#   ^ string.special.prim
+#   ^ string.special
     <../relative_1/thing>,
-#   ^ string.special.prim
+#   ^ string.special
     <relative_2/thing>
-#   ^ string.special.prim
+#   ^ string.special
 ]

--- a/test/highlight/specializes.usda
+++ b/test/highlight/specializes.usda
@@ -1,7 +1,7 @@
 def "foo" (
     specializes = <../../parent/another/thing>
     # <- variable
-    #             ^ string.special.prim
+    #             ^ string.special
 )
 {
 }
@@ -9,7 +9,7 @@ def "foo" (
 def "foo" (
     specializes = [</foo>, </bar>, ]
     # <- variable
-    #              ^ string.special.prim
+    #              ^ string.special
 )
 {
 }

--- a/test/highlight/subLayers.usda
+++ b/test/highlight/subLayers.usda
@@ -3,6 +3,6 @@
     subLayers = [
     # <- variable
         @./model_sub.usda@ (offset = 1)
-        # <- string.special.asset
+        # <- text.uri
     ]
 )

--- a/test/highlight/variantSet.usda
+++ b/test/highlight/variantSet.usda
@@ -32,7 +32,7 @@ over "SomeSphere" (
             add references = [@foo.usda@]
             # <- function.call
             #   ^ variable
-            #                 ^ string.special.asset
+            #                 ^ text.uri
         )
         {
             over "blah"


### PR DESCRIPTION
The highlights that come out of box are mostly meant for Neovim. The maintainers are https://github.com/nvim-treesitter/nvim-treesitter/pull/4774 had some suggestions related to 1. Simplifying the highlights.scm 2. Preferences related to highlight group naming.

Those changes + unittests have been added here.